### PR TITLE
remove pytest install requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ The best way to run the tests is in an interactive python session:
 ```python
 import matplotlib
 matplotib.use('agg')
-import probscale
-probscale.test()
+from probscale import tests
+tests.test()
 ```

--- a/check_probscale.py
+++ b/check_probscale.py
@@ -5,6 +5,6 @@ matplotlib.use('agg')
 from matplotlib.pyplot import style
 style.use('classic')
 
-import probscale
-status = probscale.test(*sys.argv[1:])
+from probscale import tests
+status = tests.test(*sys.argv[1:])
 sys.exit(status)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,8 +85,8 @@ It's easiest to run the tests from an interactive python session:
 
     import matplotlib
     matplotlib.use('agg')
-    import probscale
-    probscale.test()
+    from probscale import tests
+    tests.test()
 
 API References
 ==============

--- a/probscale/__init__.py
+++ b/probscale/__init__.py
@@ -2,6 +2,5 @@ from matplotlib import scale
 
 from .viz import *
 from .probscale import ProbScale
-from .tests import test
 
 scale.register_scale(ProbScale)


### PR DESCRIPTION
This package installs `pytest` when installed through conda-forge, and fails upon import when installed through pip since `pytest` is not listed in either the requirements.txt file, or in `setup.py`. The `pytest` package should only be a requirement for contributors or those wishing to run the tests, not for all users wishing to import `probscale`. 

This PR eliminates the dependency while maintaining the ability to import and run the test suite directly from `probscale`, and alters only 3 lines of code.

I have also provided adjustments to the documentation so that the instructions on importing and running the code will match the altered test import statements.

All tests still pass, and the code is compatible with python2 and python3 import rules.

I have not checked travis, or altered the conda recipe.

