### PR TITLE
updated README.md about the dependency resolve issue on pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,37 @@ Real probability scales for matplotlib
 
 ## Installation
 
+### Dependecies
+This library depends on **pytest** framework. If you don't have this installed you may wind up getting dependcy error like
+> File "", line 1, in 
+File "/usr/local/lib/python3.5/dist-packages/probscale/init.py", line 5, in 
+from .tests import test
+File "/usr/local/lib/python3.5/dist-packages/probscale/tests/init.py", line 3, in 
+import pytest
+ImportError: No module named 'pytest'
+
+So install **pytest** before installing **probscale**
+
+### How to install pyteset?
+You can install **pytest** with **pip** package manager. 
+
+For Python 3 version
+`pip3 install pytest`
+ 
+or
+
+for Python 2 version
+`pip install pytest`
+
+If you need **superuser** mode, you can do,
+For Python 3 version
+`sudo -H pip3 install pytest`
+ 
+or
+
+for Python 2 version
+`sudo -H pip install pytest`
+
 ### Official releases
 
 Official releases are available through the conda-forge channel or pip


### PR DESCRIPTION
This library depends on `pytest`. But it is not mentioned in the `README.md` section. So it's a bit confusing. I have forked the library and updated the `README.md` which includes how to resolve the dependency issues. Please check it!