### PR TITLE
Suppress warning 'invalid value encountered in sign'

### DIFF
--- a/probscale/probscale.py
+++ b/probscale/probscale.py
@@ -1,4 +1,5 @@
 import numpy
+import warnings
 from matplotlib.scale import ScaleBase
 from matplotlib.ticker import (
     FixedLocator,
@@ -29,7 +30,9 @@ class _minimal_norm(object):
         """
 
         guts = -x**2 * (4.0 / numpy.pi + cls._A * x**2) / (1.0 + cls._A * x**2)
-        return numpy.sign(x) * numpy.sqrt(1.0 - numpy.exp(guts))
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', 'invalid value encountered in sign')
+            return numpy.sign(x) * numpy.sqrt(1.0 - numpy.exp(guts))
 
     @classmethod
     def _approx_inv_erf(cls, z):
@@ -41,7 +44,9 @@ class _minimal_norm(object):
 
         _b = (2 / numpy.pi / cls._A) + (0.5 * numpy.log(1 - z**2))
         _c = numpy.log(1 - z**2) / cls._A
-        return numpy.sign(z) * numpy.sqrt(numpy.sqrt(_b**2 - _c) - _b)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', 'invalid value encountered in sign')
+            return numpy.sign(z) * numpy.sqrt(numpy.sqrt(_b**2 - _c) - _b)
 
     @classmethod
     def ppf(cls, q):

--- a/probscale/tests/test_probscale.py
+++ b/probscale/tests/test_probscale.py
@@ -72,6 +72,20 @@ def test_minimal_norm_cdf(mn, mn_input):
     assert numpy.all(numpy.abs(diff) < 0.001)
 
 
+def test_sign_with_nan_no_warning(mn):
+    with pytest.warns(None) as record:
+        res = mn._approx_erf(numpy.nan)
+    assert not record
+    assert numpy.isnan(res)
+
+
+def test_sign_with_nan_no_warning(mn):
+    with pytest.warns(None) as record:
+        res = mn._approx_inv_erf(numpy.nan)
+    assert not record
+    assert numpy.isnan(res)
+
+
 @pytest.mark.mpl_image_compare(
     baseline_dir='baseline_images/test_probscale',
     tolerance=TOLERANCE,


### PR DESCRIPTION
During autoscaling of a probscaled axis, limit_range_for_scale is
called with (0, 1, inf) and returns inf, 1. The inverse transform
then yields nan, -2.32... for these values. The nan-value raises the
warning in _approx_erf (Windows only, see numpy issue #8945).
Sign(nan) shouldn't raise a warning as the docs explain it returns
nan for nan input.
Fixes #65. 