### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"      # Location of your workflow files
+    schedule:
+      interval: "weekly"  # Options: daily, weekly, monthly

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,4 +1,6 @@
 name: Lint with Black
+permissions:
+  contents: read
 
 on: [push, pull_request]
 

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,4 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: psf/black@stable

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,4 +11,4 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - uses: psf/black@stable
+      - uses: psf/black@8a737e727ac5ab2f1d4cf5876720ed276dc8dc4b # 25.1.0

--- a/.github/workflows/check-test-coverage.yml
+++ b/.github/workflows/check-test-coverage.yml
@@ -1,4 +1,6 @@
 name: Coverage (with doctests)
+permissions:
+  contents: read
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/check-test-coverage.yml
+++ b/.github/workflows/check-test-coverage.yml
@@ -23,7 +23,7 @@ jobs:
         export MPL_IMGCOMP_TOLERANCE=20
         coverage run -m pytest --mpl --doctest-glob="probscale/*.py" --cov-report=xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # v1
       with:
         # directory: ./coverage/reports/
         flags: unittests

--- a/.github/workflows/check-test-coverage.yml
+++ b/.github/workflows/check-test-coverage.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Setup Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Publish Python Package
+permissions:
+  contents: read
 
 on:
   release:

--- a/.github/workflows/python-runlinter.yml
+++ b/.github/workflows/python-runlinter.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/python-runlinter.yml
+++ b/.github/workflows/python-runlinter.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Lint with flake8
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/python-runtests-all.yml
+++ b/.github/workflows/python-runtests-all.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/python-runtests-all.yml
+++ b/.github/workflows/python-runtests-all.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Run units test (w/ img comps)
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions
- adding a depandabot file for GHA
